### PR TITLE
Adding WPE browser support to Linaro CDM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+PWD = $(shell pwd)
+
+all: ocdm_lib
+ocdm_lib:
+	$(MAKE) -C $(PWD)/src/browser/wpe/opencdm/ all
+
+
+clean: ocdm_lib_clean cdm_client_clean
+
+ocdm_lib_clean:
+	$(MAKE) -C $(PWD)/src/browser/wpe/opencdm/ clean
+cdm_client_clean:
+
+install: ocdm_lib_install
+
+ocdm_lib_install:
+	$(MAKE) -C $(PWD)/src/browser/wpe/opencdm/ install

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Currently OCDM development is compatible with following Web browers:
  * Linux
 * Opera SDK
  * Linux
+* WPE Browser (support work currently in progress)
+ 
 
 ## Folder Structure
 

--- a/src/browser/media_open_cdm.gypi
+++ b/src/browser/media_open_cdm.gypi
@@ -115,6 +115,17 @@
             '<(DEPTH)/media/cdm/ppapi/external_clear_key/cdm_video_decoder.cc',
             '<(DEPTH)/media/cdm/ppapi/external_clear_key/cdm_video_decoder.h',
           ],
+          'include_dirs': [
+            '<(DEPTH)/media/cdm/ppapi',
+            '../cdm',
+            '../mediaengine',
+            '../com/cdm',
+            '../com/cdm/rpc',
+            '../com/common/rpc',
+            '../com/common/shmemsem',
+            '../com/mediaengine/rpc',
+            '../include',
+          ],
           # TODO(jschuh): crbug.com/167187 fix size_t to int truncations.
           'msvs_disabled_warnings': [ 4267, ],
         },

--- a/src/browser/wpe/opencdm/Makefile
+++ b/src/browser/wpe/opencdm/Makefile
@@ -1,0 +1,78 @@
+ #
+ # Copyright (C) 2016 TATA ELXSI
+ # Copyright (C) 2016 Metrological
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without
+ # modification, are permitted provided that the following conditions
+ # are met:
+ # 1. Redistributions of source code must retain the above copyright
+ #    notice, this list of conditions and the following disclaimer.
+ # 2. Redistributions in binary form must reproduce the above copyright
+ #    notice, this list of conditions and the following disclaimer in the
+ #    documentation and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ # "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ # LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ # PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ # HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ # SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ # LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ # DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #
+RM := rm  -rf
+PWD = $(shell pwd)
+OCDM_DIR = $(PWD)/../../..
+OCDM_WPE_DIR = $(PWD)/..
+CFLAGS_L := -fPIC -D_REENTRANT -Wall $(LDFLAGS)
+
+MODULES   := cdm mediaengine common com/cdm/rpc com/cdm  com/mediaengine/rpc com/common/shmemsem
+OCDM_SOURCES_C =  $(wildcard $(OCDM_DIR)/com/common/rpc/*.c)
+OCDM_SOURCES_CPP = $(wildcard $(OCDM_DIR)/browser/wpe/opencdm/*.cpp)
+OCDM_SOURCES_CC_DIR   := $(addprefix $(OCDM_DIR)/,$(MODULES))
+OCDM_SOURCES_CC     := $(foreach sdir,$(OCDM_SOURCES_CC_DIR),$(wildcard $(sdir)/*.cc))
+OCDM_HEADERS = $(wildcard $(OCDM_DIR)/com/common/rpc/*.h)
+OCDM_HEADERS := $(OCDM_HEADERS) $(wildcard $(OCDM_DIR)/browser/wpe/opencdm/*.h)
+OCDM_HEADERS := $(OCDM_HEADERS) $(foreach sdir,$(OCDM_SOURCES_CC_DIR),$(wildcard $(sdir)/*.h))
+OCDM_HEADER_PATH := $(foreach sdir,$(OCDM_SOURCES_CC_DIR),$(addprefix -I,$(sdir)/))
+
+OCDM_OBJECTS_C = $(OCDM_SOURCES_C:.c=.o)
+OCDM_OBJECTS_CC = $(OCDM_SOURCES_CC:.cc=.o)
+OCDM_OBJECTS_CPP = $(OCDM_SOURCES_CPP:.cpp=.o)
+OCDM_INCLUDES :=  $(OCDM_HEADER_PATH) \
+                 -I $(OCDM_DIR)/include \
+	         -I $(OCDM_DIR)/com/common/rpc \
+		 -I $(OCDM_DIR)/browser/wpe/opencdm
+
+CXFLAGS := -std=c++11 -g $(OCDM_INCLUDES) -pthread $(CXXFLAGS)
+CFLAGS := -g $(OCDM_INCLUDES) -pthread $(CPPFLAGS)
+
+
+all: ocdm install
+
+ocdm: $(OCDM_OBJECTS_C)  $(OCDM_OBJECTS_CC)  ${OCDM_OBJECTS_CPP}
+	@echo "Compiling ..."
+	@mkdir -p $(OCDM_WPE_DIR)/lib
+	$(CXX)  ${OCDM_OBJECTS_C}  ${OCDM_OBJECTS_CC} ${OCDM_OBJECTS_CPP} -shared -o $(OCDM_WPE_DIR)/lib/lib$@.so
+
+%.o: %.c
+	$(CC) $(CFLAGS)  $(CFLAGS_L) -o $@ -c $<
+%.o: %.cc
+	$(CXX) $(CXFLAGS) $(CFLAGS_L) -o $@ -c $<
+%.o: %.cpp
+	$(CXX) $(CXFLAGS) $(CFLAGS_L) -o $@ -c $<
+
+install:$(OCDM_HEADERS)
+	@mkdir -p $(OCDM_WPE_DIR)/include
+	@cp -r $(OCDM_HEADERS) $(OCDM_WPE_DIR)/include/
+
+.PHONY: clean
+clean:
+	@echo "Cleaning ..."
+	@$(RM)  ${OCDM_OBJECTS_C}  ${OCDM_OBJECTS_CC} ${OCDM_OBJECTS_CPP}
+	@rm -f $(OCDM_WPE_DIR)/lib/libocdm.so
+	@rm -f $(OCDM_WPE_DIR)/include/*

--- a/src/browser/wpe/opencdm/open_cdm.cpp
+++ b/src/browser/wpe/opencdm/open_cdm.cpp
@@ -1,0 +1,344 @@
+/*
+ * Copyright 2016-2017 TATA ELXSI
+ * Copyright 2016-2017 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "open_cdm.h"
+
+#include <cdm_logging.h>
+#include <cstdlib>
+#include <open_cdm_common.h>
+#include <open_cdm_mediaengine_factory.h>
+#include <open_cdm_platform_factory.h>
+
+using namespace std;
+
+namespace media {
+
+OpenCdm::OpenCdm()
+    : media_engine_(NULL)
+    , platform_(NULL) {
+  CDM_DLOG() << "OpenDecryptor construct: key_system";
+  platform_ = OpenCdmPlatformInterfaceFactory::Create(this);
+  m_eState = KEY_SESSION_INIT;
+}
+
+OpenCdm::~OpenCdm() {
+  CDM_DLOG() << "OpenCDM destruct";
+  // clean up resources
+  if (media_engine_) {
+    delete(media_engine_);
+  }
+
+  if (platform_) {
+    platform_->MediaKeySessionRelease(m_session_id.session_id, m_session_id.session_id_len);
+    delete(platform_);
+  }
+}
+
+void OpenCdm::SelectKeySystem(const std::string& key_system) {
+  CDM_DLOG() << "OpenCdm: SelectKeySystem$" << "\n";
+  m_key_system = key_system;
+  platform_->MediaKeys(key_system);
+  m_eState = KEY_SESSION_INIT;
+}
+
+void OpenCdm::SelectSession(const std::string& session_id_rcvd) {
+  CDM_DLOG() << " Enter : SelectSession";
+  m_session_id.session_id = strdup(session_id_rcvd.c_str());
+  m_session_id.session_id_len = (uint32_t)session_id_rcvd.size();
+}
+
+int OpenCdm::SetServerCertificate(const uint8_t* server_certificate_data,
+                                  uint32_t server_certificate_data_size) {
+  MediaKeySetServerCertificateResponse ret = platform_->MediaKeySetServerCertificate((uint8_t*)server_certificate_data, server_certificate_data_size);
+  if (ret.platform_response ==  PLATFORM_CALL_SUCCESS)
+    return (true);
+  else
+    return (false);
+}
+
+int OpenCdm::CreateSession(const std::string& initDataType, unsigned char* pbInitData, int cbInitData, std::string& session_id) {
+  int ret = 1;
+  m_eState = KEY_SESSION_INIT;
+  CDM_DLOG() << " Enter : CreateSession";
+  MediaKeysCreateSessionResponse response = platform_->MediaKeysCreateSession(initDataType, pbInitData, cbInitData);
+  CDM_DLOG() << "Contin : CreateSession ";
+  if (response.platform_response == PLATFORM_CALL_SUCCESS) {
+    CDM_DLOG() << "New Session created";
+    m_session_id = response.session_id;
+    if (KEY_SESSION_INIT == m_eState)
+      m_eState = KEY_SESSION_WAITING_FOR_MESSAGE;
+    ret = 0;
+  } else {
+        CDM_DLOG() << "FAIL to create session!";
+        m_eState = KEY_SESSION_ERROR;
+  }
+
+  session_id.assign(m_session_id.session_id, m_session_id.session_id_len);// initializing out parameter.
+
+  return ret;
+}
+
+// caller provided buffer, MAX_LENGTH...
+int OpenCdm::GetKeyMessage(std::string& challenge, int* challengeLength,
+    unsigned char* licenseURL, int* urlLength) {
+
+  std::unique_lock<std::mutex> lck(m_mtx);
+  CDM_DLOG() << "GetKeyMessage >> invoked from ocdm :: estate = " << m_eState << "\n";
+
+  while (m_eState == KEY_SESSION_WAITING_FOR_MESSAGE) {
+    CDM_DLOG() << "Waiting for key message!";
+    m_cond_var.wait(lck);
+  }
+
+  CDM_DLOG() << "Key message should be ready or no need key challenge/message."<< "\n" ;
+
+  if (m_eState == KEY_SESSION_MESSAGE_RECEIVED) {
+    char temp[m_message.length()];
+
+    m_message.copy(temp,m_message.length(),0);
+    challenge.assign((const char*)temp, m_message.length());
+    strncpy((char*)licenseURL, (const char*)m_dest_url.c_str(), m_dest_url.length());
+    *challengeLength = m_message.length();
+    *urlLength = m_dest_url.length();
+    char msg[m_message.length()];
+    m_message.copy( msg, m_message.length() , 0);
+    CDM_DLOG() << "setting m_eState to KEY_SESSION_WAITING_FOR_LICENSE";
+    m_eState = KEY_SESSION_WAITING_FOR_LICENSE;
+  }
+
+  if (m_eState == KEY_SESSION_READY) {
+    *challengeLength = 0;
+    *licenseURL= 0;
+  }
+  return 0;
+}
+
+int OpenCdm::Load(std::string& responseMsg) {
+  int ret = 1;
+  CDM_DLOG() << "Load >> invoked from ocdm :: estate = " << m_eState << "\n";
+  CDM_DLOG() << "Load session with info exisiting key.";
+  
+  m_eState = KEY_SESSION_WAITING_FOR_LOAD_SESSION;
+  MediaKeysLoadSessionResponse status = platform_->MediaKeysLoadSession(m_session_id.session_id, m_session_id.session_id_len);
+  if (status.platform_response ==  PLATFORM_CALL_SUCCESS) {
+    CDM_DLOG() << "Load session with info exisiting key complete.";
+
+     while (m_eState == KEY_SESSION_WAITING_FOR_LOAD_SESSION) {
+       CDM_DLOG() << "Waiting for load message!";
+       std::unique_lock<std::mutex> lck(m_mtx);
+       m_cond_var.wait(lck);
+     }
+
+     if (m_eState == KEY_SESSION_UPDATE_LICENSE || m_eState == KEY_SESSION_MESSAGE_RECEIVED) {
+       while (m_eState == KEY_SESSION_LOADED) {
+         CDM_DLOG() << "Waiting for Load message!";
+         std::unique_lock<std::mutex> lck(m_mtx);
+         m_cond_var.wait(lck);
+       }
+       if (m_eState == KEY_SESSION_UPDATE_LICENSE) {
+         ret = 0;
+         CDM_DLOG() << "setting m_eState to KEY_SESSION_LOADED";
+         m_eState = KEY_SESSION_LOADED; //TODO : tobe rechecked and updated
+       }
+       if (m_eState == KEY_SESSION_MESSAGE_RECEIVED) {
+         ret = 0;
+         CDM_DLOG() << "setting m_eState to KEY_SESSION_EXPIRED";
+         m_eState = KEY_SESSION_EXPIRED; //TODO : tobe rechecked and updated
+         responseMsg.assign("message:");
+      }
+    }
+  }
+  responseMsg.append(m_message.c_str(), m_message.length());
+  return ret;
+}
+
+int OpenCdm::Update(uint8_t* pbResponse, int cbResponse, std::string& responseMsg) {
+  CDM_DLOG() << "Update >> invoked from ocdm :: estate = " << m_eState << "\n";
+
+  int ret = 1;
+  CDM_DLOG() << "Update session with info from server.";
+  platform_->MediaKeySessionUpdate((uint8_t*)pbResponse, cbResponse, m_session_id.session_id, m_session_id.session_id_len);
+  CDM_DLOG() << "Update session with info from server complete.";
+  while (m_eState == KEY_SESSION_WAITING_FOR_LICENSE) {
+    CDM_DLOG() << "Waiting for license update status!" << "\n";
+    fflush(stdout);
+    std::unique_lock<std::mutex> lck(m_mtx);
+    m_cond_var.wait(lck);
+  }
+  if (m_eState == KEY_SESSION_UPDATE_LICENSE || m_eState == KEY_SESSION_REMOVED) {
+    ret = 0;
+  }
+  else {
+    CDM_DLOG() <<"Got license update status!" << "\n";
+    fflush(stdout);
+    if (m_eState == KEY_SESSION_MESSAGE_RECEIVED) {
+      m_eState = KEY_SESSION_WAITING_FOR_LICENSE;
+      responseMsg.assign("message:");
+    }
+  }
+  responseMsg.append(m_message.c_str(), m_message.length());
+  return ret;
+}
+
+int OpenCdm::Remove(std::string& responseMsg) {
+  CDM_DLOG() << "Remove >> invoked from ocdm :: estate = " << m_eState << "\n";
+  int ret = 1;
+  CDM_DLOG() << "\nEnd";
+  CDM_DLOG() << "Remove session with info exisiting key.";
+
+  m_eState = KEY_SESSION_WAITING_FOR_LICENSE_REMOVAL;
+  MediaKeySessionRemoveResponse status = platform_->MediaKeySessionRemove(m_session_id.session_id, m_session_id.session_id_len);
+  if (status.platform_response ==  PLATFORM_CALL_SUCCESS) {
+    CDM_DLOG() << "Remove session with info exisiting key complete.";
+  
+    while (m_eState == KEY_SESSION_WAITING_FOR_LICENSE_REMOVAL) {
+      CDM_DLOG() << "Waiting for remove message!";
+      std::unique_lock<std::mutex> lck(m_mtx);
+      m_cond_var.wait(lck);
+    }
+
+    if (m_eState == KEY_SESSION_REMOVED || m_eState == KEY_SESSION_MESSAGE_RECEIVED) {
+        while (m_eState == KEY_SESSION_REMOVED) {
+           CDM_DLOG() << "Waiting for remove message!";
+           std::unique_lock<std::mutex> lck(m_mtx);
+           m_cond_var.wait(lck);
+        }
+        if (m_eState == KEY_SESSION_MESSAGE_RECEIVED) {
+           ret = 0;
+           CDM_DLOG() << "setting m_eState to KEY_SESSION_REMOVED";
+           m_eState = KEY_SESSION_REMOVED;//TODO : tobe rechecked and updated
+           responseMsg.assign("message:");
+      }
+   }
+  }
+  responseMsg.append(m_message.c_str(), m_message.length());
+  return ret;
+}
+
+int OpenCdm::Close() {
+  CDM_DLOG() << "Close >> invoked from ocdm :: estate = " << m_eState << "\n";
+  CDM_DLOG() << "\nEnd";
+  CDM_DLOG() << "Close session with info existing key.";
+  MediaKeySessionCloseResponse status = platform_->MediaKeySessionClose(m_session_id.session_id, m_session_id.session_id_len);
+  CDM_DLOG() << "Close session with info existing key complete.";
+  if (status.platform_response ==  PLATFORM_CALL_SUCCESS) {
+    m_eState = KEY_SESSION_CLOSED;
+    return (true);
+  }
+  else
+    return (false);
+}
+
+int OpenCdm::ReleaseMem() {
+  if(media_engine_)
+     return media_engine_->ReleaseMem();
+
+  return (false);
+}
+
+int OpenCdm::Decrypt(unsigned char* encryptedData, uint32_t encryptedDataLength, unsigned char* ivData, uint32_t ivDataLength) {
+  int ret = 1;
+  uint32_t outSize;
+  CDM_DLOG() << "OpenCdm::Decrypt session_id : " << m_session_id.session_id << endl;
+  CDM_DLOG() << "OpenCdm::Decrypt session_id_len : " << m_session_id.session_id_len << endl;
+  CDM_DLOG() << "OpenCdm::Decrypt encryptedDataLength : " << encryptedDataLength << endl;
+  CDM_DLOG() << "OpenCdm::Decrypt ivDataLength : " << ivDataLength << endl;
+  // mediaengine instantiation
+  if (!media_engine_) {
+    // FIXME:(ska): handle mutiple sessions
+    media_engine_ = OpenCdmMediaengineFactory::Create(m_key_system, m_session_id);
+    CDM_DLOG() << "::" << endl;
+    if (!media_engine_){
+      CDM_DLOG() << "::" << endl;
+      return ret;
+    }
+  }
+
+  CDM_DLOG() << "Returned back to OpenCdm::Decrypt";
+  DecryptResponse dr = media_engine_->Decrypt((const uint8_t*)ivData, ivDataLength,
+      (const uint8_t*)encryptedData, encryptedDataLength, (uint8_t*)encryptedData, outSize);
+
+  CDM_DLOG() << "media_engine_->Decrypt done " << dr.platform_response;
+
+  return 0;
+}
+
+bool OpenCdm::IsTypeSupported(const std::string& keySystem, const std::string& mimeType) {
+  MediaKeyTypeResponse ret;
+
+  ret = platform_->IsTypeSupported(keySystem, mimeType);
+  CDM_DLOG() << "IsTypeSupported ";
+
+  if (ret.platform_response ==  PLATFORM_CALL_SUCCESS )
+    return (true);
+  else
+    return (false);
+}
+
+void OpenCdm::ReadyCallback(OpenCdmPlatformSessionId platform_session_id) {
+
+  CDM_DLOG() << "OpenCdm::ReadyCallback";
+
+  std::unique_lock<std::mutex> lck(m_mtx);
+  m_eState = KEY_SESSION_READY;
+  m_cond_var.notify_all();
+
+  CDM_DLOG() << "OpenCdm::ReadyCallback";
+}
+
+void OpenCdm::ErrorCallback(OpenCdmPlatformSessionId platform_session_id,
+    uint32_t sys_err, std::string err_msg) {
+  CDM_DLOG() << "OpenCdm::ErrorCallback";
+  std::unique_lock<std::mutex> lck(m_mtx);
+  m_message = err_msg;
+  m_eState = KEY_SESSION_ERROR;
+  m_cond_var.notify_all();
+}
+
+void OpenCdm::MessageCallback(OpenCdmPlatformSessionId platform_session_id,
+    std::string message, std::string destination_url) {
+
+  CDM_DLOG() << "OpenCdm::MessageCallback:";
+  fflush(stdout);
+  CDM_DLOG() << "Start MessageCallback";
+  for(int i = 0; i < message.length(); i++)
+    printf("%2x ",message[i]);
+  CDM_DLOG() << "End MessageCallback";
+  std::unique_lock<std::mutex> lck(m_mtx);
+  m_message = message;
+  m_dest_url = destination_url;
+  m_eState = KEY_SESSION_MESSAGE_RECEIVED;
+  m_cond_var.notify_all();
+}
+
+void OpenCdm::OnKeyStatusUpdateCallback(OpenCdmPlatformSessionId platform_session_id, std::string message) {
+
+  if (message == "KeyUsable")
+    m_eState = KEY_SESSION_UPDATE_LICENSE;
+  else if (message == "KeyReleased")
+    m_eState = KEY_SESSION_REMOVED;
+  else if (message == "KeyExpired")
+    m_eState = KEY_SESSION_EXPIRED;
+  else
+    m_eState = KEY_SESSION_ERROR;
+
+  m_message = message;
+  m_cond_var.notify_all();
+
+  CDM_DLOG() << "Got key status update ->  " << message;
+}
+} // namespace media

--- a/src/browser/wpe/opencdm/open_cdm.h
+++ b/src/browser/wpe/opencdm/open_cdm.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2016-2017 TATA ELXSI
+ * Copyright 2016-2017 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OCDM_WRAPPER_H_
+#define OCDM_WRAPPER_H_
+
+#include <condition_variable>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <open_cdm_common.h>
+#include <open_cdm_mediaengine.h>
+#include <open_cdm_platform.h>
+#include <open_cdm_platform_com_callback_receiver.h>
+#include <stdlib.h>
+#include <string>
+#include <string.h>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+namespace media {
+
+class OpenCdm : public media::OpenCdmPlatformComCallbackReceiver {
+private:
+  enum InternalSessionState {
+    // Initialized.
+    KEY_SESSION_INIT = 0,
+    // Session created, waiting for message callback.
+    KEY_SESSION_WAITING_FOR_MESSAGE = 1,
+    KEY_SESSION_MESSAGE_RECEIVED = 2,
+    KEY_SESSION_WAITING_FOR_LICENSE = 3,
+    KEY_SESSION_UPDATE_LICENSE = 4,
+    KEY_SESSION_READY = 5,
+    KEY_SESSION_ERROR = 6,
+    KEY_SESSION_LOADED = 7,
+    KEY_SESSION_WAITING_FOR_LICENSE_REMOVAL = 8,
+    KEY_SESSION_WAITING_FOR_LOAD_SESSION = 9,
+    KEY_SESSION_REMOVED = 10,
+    KEY_SESSION_CLOSED = 11,
+    KEY_SESSION_EXPIRED = 12
+  };
+
+public:
+  OpenCdm();
+  ~OpenCdm() override;
+
+  int CreateSession(const std::string& ,unsigned char* , int, std::string&);
+  int GetKeyMessage(std::string&, int*, unsigned char*, int*);
+  int SetServerCertificate(const uint8_t*, uint32_t);
+  int Load(std::string&);
+
+int Update(uint8_t*, int, std::string&);
+//  int Update(unsigned char*, int, std::string&);
+
+  int Remove(std::string&);
+  int Close();
+  void SelectKeySystem(const std::string& );
+  void SelectSession(const std::string& );
+  bool IsTypeSupported(const  std::string& keySystem,const  std::string& mimeType);
+  int Decrypt(unsigned char*, uint32_t, unsigned char*, uint32_t);
+  int ReleaseMem();
+
+private:
+  OpenCdmMediaengine* media_engine_;
+  OpenCdmPlatform* platform_;
+  OpenCdmPlatformSessionId m_session_id;
+
+  std::string m_key_system;
+  std::mutex  m_mtx;
+  std::string m_message;
+  std::string m_dest_url;
+
+  std::condition_variable  m_cond_var;
+  volatile InternalSessionState m_eState;
+
+  void ReadyCallback(OpenCdmPlatformSessionId platform_session_id) override;
+  void ErrorCallback(OpenCdmPlatformSessionId platform_session_id,
+                     uint32_t sys_err, std::string err_msg) override;
+  void MessageCallback(OpenCdmPlatformSessionId platform_session_id, std::string message,
+                       std::string destination_url) override;
+  void OnKeyStatusUpdateCallback(OpenCdmPlatformSessionId platform_session_id,
+                                 std::string message) override;
+
+};
+} // namespace media
+#endif

--- a/src/cdm/open_cdm_platform.h
+++ b/src/cdm/open_cdm_platform.h
@@ -18,8 +18,8 @@
 #define MEDIA_CDM_PPAPI_EXTERNAL_OPEN_CDM_CDM_OPEN_CDM_PLATFORM_H_
 
 #include <string>
-#include "media/cdm/ppapi/external_open_cdm/src/cdm/open_cdm_platform_common.h"
-#include "media/cdm/ppapi/external_open_cdm/src/cdm/open_cdm_platform_com_callback_receiver.h"
+#include "open_cdm_platform_common.h"
+#include "open_cdm_platform_com_callback_receiver.h"
 
 namespace media {
 
@@ -45,11 +45,24 @@ class OpenCdmPlatform {
       const uint8_t *pbKey, uint32_t cbKey, char *session_id_val,
       uint32_t session_id_len) = 0;
 
+  // EME equivalent: media_key_session_.setServerCertificate()
+  virtual MediaKeySetServerCertificateResponse MediaKeySetServerCertificate(
+      const uint8_t *pbServerCert, uint32_t cbServerCert) = 0;
+
+  // EME equivalent: media_key_session_.remove()
+  virtual MediaKeySessionRemoveResponse MediaKeySessionRemove(
+      char *session_id_val, uint32_t session_id_len) = 0;
+
+  // EME equivalent: media_key_session_.close()
+  virtual MediaKeySessionCloseResponse MediaKeySessionClose(
+      char *session_id_val, uint32_t session_id_len) = 0;
+
+  //EME equivalent : media_key_.isTypeSupported()
+  virtual MediaKeyTypeResponse IsTypeSupported(const std::string&,
+                                            const std::string&) = 0;
   // EME equivalent: media_key_session_.release()
   virtual MediaKeySessionReleaseResponse MediaKeySessionRelease(
       char *session_id_val, uint32_t session_id_len) = 0;
-
-
   virtual ~OpenCdmPlatform() {
   }
   OpenCdmPlatform(OpenCdmPlatformComCallbackReceiver *callback_receiver_);

--- a/src/cdm/open_cdm_platform_com.h
+++ b/src/cdm/open_cdm_platform_com.h
@@ -17,9 +17,9 @@
 #ifndef MEDIA_CDM_PPAPI_EXTERNAL_OPEN_CDM_CDM_OPEN_CDM_PLATFORM_COM_H_
 #define MEDIA_CDM_PPAPI_EXTERNAL_OPEN_CDM_CDM_OPEN_CDM_PLATFORM_COM_H_
 
-#include "media/cdm/ppapi/external_open_cdm/src/cdm/open_cdm_platform_common.h"
-#include "media/cdm/ppapi/external_open_cdm/src/cdm/open_cdm_platform.h"
-#include "media/cdm/ppapi/external_open_cdm/src/cdm/open_cdm_platform_com_callback_receiver.h"
+#include "open_cdm_platform_common.h"
+#include "open_cdm_platform.h"
+#include "open_cdm_platform_com_callback_receiver.h"
 
 #include <string>
 

--- a/src/cdm/open_cdm_platform_common.h
+++ b/src/cdm/open_cdm_platform_common.h
@@ -42,14 +42,25 @@ struct OpenCdmPlatformSessionId {
 
 struct MediaKeysResponse : public PlatformResponse {
 };
+struct MediaKeySetServerCertificateResponse : public PlatformResponse {
+};
+struct MediaKeyTypeResponse : public PlatformResponse {
+};
 struct MediaKeysCreateSessionResponse : public PlatformResponse {
   OpenCdmPlatformSessionId session_id;
   std::string licence_req;
 };
+
+struct MediaKeySessionRemoveResponse : public PlatformResponse {
+};
+struct MediaKeySessionCloseResponse : public PlatformResponse {
+};
 struct MediaKeysLoadSessionResponse : public PlatformResponse {
 };
+
 struct MediaKeySessionUpdateResponse : public PlatformResponse {
 };
+
 struct MediaKeySessionReleaseResponse : public PlatformResponse {
 };
 

--- a/src/cdm/open_cdm_platform_factory.h
+++ b/src/cdm/open_cdm_platform_factory.h
@@ -17,9 +17,9 @@
 #ifndef MEDIA_CDM_PPAPI_EXTERNAL_OPEN_CDM_CDM_OPEN_CDM_PLATFORM_FACTORY_H_
 #define MEDIA_CDM_PPAPI_EXTERNAL_OPEN_CDM_CDM_OPEN_CDM_PLATFORM_FACTORY_H_
 
-#include "media/cdm/ppapi/external_open_cdm/src/cdm/open_cdm_platform.h"
-#include "media/cdm/ppapi/external_open_cdm/src/cdm/open_cdm_platform_impl.h"
-#include "media/cdm/ppapi/external_open_cdm/src/cdm/open_cdm_platform_com_callback_receiver.h"
+#include <open_cdm_platform.h>
+#include <open_cdm_platform_impl.h>
+#include <open_cdm_platform_com_callback_receiver.h>
 
 namespace media {
 

--- a/src/cdm/open_cdm_platform_impl.cc
+++ b/src/cdm/open_cdm_platform_impl.cc
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include "media/cdm/ppapi/external_open_cdm/src/cdm/open_cdm_platform_impl.h"
-#include "media/cdm/ppapi/external_open_cdm/src/com/cdm/open_cdm_platform_com_handler_factory.h"
-#include "media/cdm/ppapi/cdm_logging.h"
+#include "open_cdm_platform_impl.h"
+#include <open_cdm_platform_com_handler_factory.h>
+#include <cdm_logging.h>
 
 namespace media {
 
@@ -68,6 +68,38 @@ MediaKeySessionUpdateResponse OpenCdmPlatformImpl::MediaKeySessionUpdate(
   return response;
 }
 
+MediaKeySetServerCertificateResponse OpenCdmPlatformImpl::MediaKeySetServerCertificate(
+    const uint8_t *pbServerCert, uint32_t cbServerCert) {
+  CDM_DLOG() << "OpenCdmPlatformCdmiImpl::MediaKeysSetServerCertificate";
+  MediaKeySetServerCertificateResponse response;
+
+  response = com_handler_->MediaKeySetServerCertificate(pbServerCert, cbServerCert);
+
+  return response;
+}
+
+MediaKeySessionRemoveResponse OpenCdmPlatformImpl::MediaKeySessionRemove(
+    char *session_id_val, uint32_t session_id_len) {
+  CDM_DLOG() << "OpenCdmPlatformCdmiImpl::MediaKeySessionRemove";
+  MediaKeySessionRemoveResponse response;
+
+  response = com_handler_->MediaKeySessionRemove(session_id_val,
+                                                  session_id_len);
+
+  return response;
+}
+
+MediaKeySessionCloseResponse OpenCdmPlatformImpl::MediaKeySessionClose(
+    char *session_id_val, uint32_t session_id_len) {
+  CDM_DLOG() << "OpenCdmPlatformCdmiImpl::MediaKeySessionClose";
+  MediaKeySessionCloseResponse response;
+
+  response = com_handler_->MediaKeySessionClose(session_id_val,
+                                                  session_id_len);
+
+  return response;
+}
+
 MediaKeySessionReleaseResponse OpenCdmPlatformImpl::MediaKeySessionRelease(
     char *session_id_val, uint32_t session_id_len) {
   CDM_DLOG() << "OpenCdmPlatformCdmiImpl::MediaKeySessionRelease";
@@ -77,6 +109,14 @@ MediaKeySessionReleaseResponse OpenCdmPlatformImpl::MediaKeySessionRelease(
                                                   session_id_len);
 
   return response;
+}
+
+MediaKeyTypeResponse OpenCdmPlatformImpl::IsTypeSupported(
+    const std::string& keysystem,const std::string& mimeType) {
+
+    CDM_DLOG() << "OpenCdmPlatformCdmiImpl::IsTypeSupported";
+    MediaKeyTypeResponse response = com_handler_->IsTypeSupported(keysystem,mimeType);
+    return response;
 }
 
 // OpenCdmComCallbackReceiver inheritance

--- a/src/cdm/open_cdm_platform_impl.h
+++ b/src/cdm/open_cdm_platform_impl.h
@@ -18,10 +18,10 @@
 #define MEDIA_CDM_PPAPI_EXTERNAL_OPEN_CDM_CDM_OPEN_CDM_PLATFORM_IMPL_H_
 
 #include <string>
-#include "media/cdm/ppapi/external_open_cdm/src/cdm/open_cdm_platform_common.h"
-#include "media/cdm/ppapi/external_open_cdm/src/cdm/open_cdm_platform_com_callback_receiver.h"
-#include "media/cdm/ppapi/external_open_cdm/src/cdm/open_cdm_platform.h"
-#include "media/cdm/ppapi/external_open_cdm/src/cdm/open_cdm_platform_com.h"
+#include "open_cdm_platform_common.h"
+#include "open_cdm_platform_com_callback_receiver.h"
+#include "open_cdm_platform.h"
+#include "open_cdm_platform_com.h"
 
 namespace media {
 
@@ -48,10 +48,25 @@ class OpenCdmPlatformImpl : public OpenCdmPlatform,
       const uint8_t *pbKey, uint32_t cbKey, char *session_id_val,
       uint32_t session_id_len) override;
 
-  // EME equivalent: media_key_session_.release()
-  MediaKeySessionReleaseResponse MediaKeySessionRelease(
+  // EME equivalent: media_key_.set_server_certificate()
+  MediaKeySetServerCertificateResponse MediaKeySetServerCertificate(
+      const uint8_t *pbServerCert, uint32_t cbServerCert) override;
+
+  // EME equivalent: media_key_session_.remove()
+  MediaKeySessionRemoveResponse MediaKeySessionRemove(
       char *session_id_val, uint32_t session_id_len) override;
 
+  // EME equivalent: media_key_session_.close()
+  MediaKeySessionCloseResponse MediaKeySessionClose(
+      char *session_id_val, uint32_t session_id_len) override;
+
+
+// EME equivalent: media_key_session_.release()
+  MediaKeySessionReleaseResponse MediaKeySessionRelease(
+      char *session_id_val, uint32_t session_id_len) override;
+  //EME equivalent : media_key_.isTypeSupported()
+  MediaKeyTypeResponse IsTypeSupported(const std::string&,
+                                            const std::string&) override;
   // OpenCdmComCallbackReceiver inheritance
   void ErrorCallback(OpenCdmPlatformSessionId platform_session_id,
                              uint32_t sys_err, std::string err_msg) override;

--- a/src/com/cdm/open_cdm_platform_com_handler_factory.h
+++ b/src/com/cdm/open_cdm_platform_com_handler_factory.h
@@ -17,9 +17,9 @@
 #ifndef MEDIA_CDM_PPAPI_EXTERNAL_OPEN_CDM_COM_CDM_OPEN_CDM_PLATFORM_COM_HANDLER_FACTORY_H_
 #define MEDIA_CDM_PPAPI_EXTERNAL_OPEN_CDM_COM_CDM_OPEN_CDM_PLATFORM_COM_HANDLER_FACTORY_H_
 
-#include "media/cdm/ppapi/external_open_cdm/src/cdm/open_cdm_platform_com.h"
-#include "media/cdm/ppapi/external_open_cdm/src/cdm/open_cdm_platform_com_callback_receiver.h"
-#include "media/cdm/ppapi/external_open_cdm/src/com/cdm/rpc/rpc_cdm_platform_handler.h"
+#include <open_cdm_platform_com.h>
+#include <open_cdm_platform_com_callback_receiver.h>
+#include <rpc_cdm_platform_handler.h>
 
 namespace media {
 

--- a/src/com/cdm/rpc/rpc_cdm_platform_handler.h
+++ b/src/com/cdm/rpc/rpc_cdm_platform_handler.h
@@ -17,13 +17,15 @@
 #ifndef MEDIA_CDM_PPAPI_EXTERNAL_OPEN_CDM_COM_CDM_RPC_RPC_CDM_PLATFORM_HANDLER_H_
 #define MEDIA_CDM_PPAPI_EXTERNAL_OPEN_CDM_COM_CDM_RPC_RPC_CDM_PLATFORM_HANDLER_H_
 
+#include <cstring>
+#include <cstdbool>
 #include <rpc/rpc.h>
 #include <string>
 
-#include "media/cdm/ppapi/external_open_cdm/src/cdm/open_cdm_platform_common.h"
-#include "media/cdm/ppapi/external_open_cdm/src/cdm/open_cdm_platform_com.h"
-#include "media/cdm/ppapi/external_open_cdm/src/cdm/open_cdm_platform_com_callback_receiver.h"
-#include "media/cdm/ppapi/external_open_cdm/src/com/common/rpc/opencdm_callback.h"
+#include <open_cdm_platform_common.h>
+#include <open_cdm_platform_com.h>
+#include <open_cdm_platform_com_callback_receiver.h>
+#include <opencdm_callback.h>
 
 namespace media {
 
@@ -35,6 +37,9 @@ class RpcCdmPlatformHandler : public OpenCdmPlatformCom {
   // EME equivalent: new MediaKeys()
   MediaKeysResponse MediaKeys(std::string key_system) override;
 
+  //EME equivalent : media_key_.isTypeSupported()
+  MediaKeyTypeResponse IsTypeSupported(const std::string&,
+                                            const std::string&) override;
   // EME equivalent: media_keys_.createSession()
   MediaKeysCreateSessionResponse MediaKeysCreateSession(
       const std::string& init_data_type, const uint8_t* init_data,
@@ -48,6 +53,20 @@ class RpcCdmPlatformHandler : public OpenCdmPlatformCom {
   MediaKeySessionUpdateResponse MediaKeySessionUpdate(
       const uint8_t *pbKey, uint32_t cbKey, char *session_id_val,
       uint32_t session_id_len) override;
+
+  // EME equivalent: media_key_session_.set_server_certificate()
+  MediaKeySetServerCertificateResponse MediaKeySetServerCertificate(
+      const uint8_t *pbServerCert, uint32_t cbServerCert) override;
+
+  // EME equivalent: media_key_session_.remove()
+  MediaKeySessionRemoveResponse MediaKeySessionRemove(
+      char *session_id_val, uint32_t session_id_len) override;
+
+  // EME equivalent: media_key_session_.close()
+  MediaKeySessionCloseResponse MediaKeySessionClose(
+      char *session_id_val, uint32_t session_id_len) override;
+
+
 
   // EME equivalent: media_key_session_.release()
   MediaKeySessionReleaseResponse MediaKeySessionRelease(

--- a/src/com/common/rpc/opencdm_xdr.h
+++ b/src/com/common/rpc/opencdm_xdr.h
@@ -34,6 +34,14 @@ struct rpc_request_mediakeys {
 };
 typedef struct rpc_request_mediakeys rpc_request_mediakeys;
 
+struct rpc_request_certificate {
+	struct {
+		u_int certificate_len;
+		uint8_t *certificate_val;
+	} certificate;
+};
+typedef struct rpc_request_certificate rpc_request_certificate;
+
 struct rpc_request_callback_info {
 	struct {
 		u_int hostname_len;
@@ -57,6 +65,13 @@ struct rpc_request_create_session {
 };
 typedef struct rpc_request_create_session rpc_request_create_session;
 
+struct rpc_request_session_load {
+	struct {
+		u_int session_id_len;
+		char *session_id_val;
+	} session_id;
+};
+typedef struct rpc_request_session_load rpc_request_session_load;
 struct rpc_request_load_session {
 	struct {
 		u_int session_id_len;
@@ -76,6 +91,22 @@ struct rpc_request_session_update {
 	} key;
 };
 typedef struct rpc_request_session_update rpc_request_session_update;
+
+struct rpc_request_session_remove {
+	struct {
+		u_int session_id_len;
+		char *session_id_val;
+	} session_id;
+};
+typedef struct rpc_request_session_remove rpc_request_session_remove;
+
+struct rpc_request_session_close {
+	struct {
+		u_int session_id_len;
+		char *session_id_val;
+	} session_id;
+};
+typedef struct rpc_request_session_close rpc_request_session_close;
 
 struct rpc_request_session_release {
 	struct {
@@ -130,10 +161,12 @@ extern  rpc_response_generic * rpc_open_cdm_mediakeys_1_svc(rpc_request_mediakey
 #define RPC_OPEN_CDM_MEDIAKEYS_CREATE_SESSION 3
 extern  rpc_response_create_session * rpc_open_cdm_mediakeys_create_session_1(rpc_request_create_session *, CLIENT *);
 extern  rpc_response_create_session * rpc_open_cdm_mediakeys_create_session_1_svc(rpc_request_create_session *, struct svc_req *);
+extern  rpc_response_generic * rpc_open_cdm_mediakeysession_load_1(rpc_request_session_load *, CLIENT *);
+extern  rpc_response_generic * rpc_open_cdm_mediakeysession_load_1_svc(rpc_request_session_load *, struct svc_req *);
 #define RPC_OPEN_CDM_MEDIAKEYS_LOAD_SESSION 4
+#define RPC_OPEN_CDM_MEDIAKEYSESSION_UPDATE 5
 extern  rpc_response_generic * rpc_open_cdm_mediakeys_load_session_1(rpc_request_load_session *, CLIENT *);
 extern  rpc_response_generic * rpc_open_cdm_mediakeys_load_session_1_svc(rpc_request_load_session *, struct svc_req *);
-#define RPC_OPEN_CDM_MEDIAKEYSESSION_UPDATE 5
 extern  rpc_response_generic * rpc_open_cdm_mediakeysession_update_1(rpc_request_session_update *, CLIENT *);
 extern  rpc_response_generic * rpc_open_cdm_mediakeysession_update_1_svc(rpc_request_session_update *, struct svc_req *);
 #define RPC_OPEN_CDM_MEDIAKEYSESSION_RELEASE 6
@@ -142,6 +175,15 @@ extern  rpc_response_generic * rpc_open_cdm_mediakeysession_release_1_svc(rpc_re
 #define RPC_OPEN_CDM_MEDIAENGINE 7
 extern  rpc_response_generic * rpc_open_cdm_mediaengine_1(rpc_request_mediaengine_data *, CLIENT *);
 extern  rpc_response_generic * rpc_open_cdm_mediaengine_1_svc(rpc_request_mediaengine_data *, struct svc_req *);
+#define RPC_OPEN_CDM_MEDIAKEYS_SET_SERVER_CERTIFICATE 8
+extern  rpc_response_generic * rpc_open_cdm_mediakeys_set_server_certificate_1(rpc_request_certificate *, CLIENT *);
+extern  rpc_response_generic * rpc_open_cdm_mediakeys_set_server_certificate_1_svc(rpc_request_certificate *, struct svc_req *);
+#define RPC_OPEN_CDM_MEDIAKEYSESSION_REMOVE 9
+extern  rpc_response_generic * rpc_open_cdm_mediakeysession_remove_1(rpc_request_session_remove *, CLIENT *);
+extern  rpc_response_generic * rpc_open_cdm_mediakeysession_remove_1_svc(rpc_request_session_remove *, struct svc_req *);
+#define RPC_OPEN_CDM_MEDIAKEYSESSION_CLOSE 10
+extern  rpc_response_generic * rpc_open_cdm_mediakeysession_close_1(rpc_request_session_close *, CLIENT *);
+extern  rpc_response_generic * rpc_open_cdm_mediakeysession_close_1_svc(rpc_request_session_close *, struct svc_req *);
 extern int open_cdm_1_freeresult (SVCXPRT *, xdrproc_t, caddr_t);
 
 #else /* K&R C */
@@ -154,10 +196,12 @@ extern  rpc_response_generic * rpc_open_cdm_mediakeys_1_svc();
 #define RPC_OPEN_CDM_MEDIAKEYS_CREATE_SESSION 3
 extern  rpc_response_create_session * rpc_open_cdm_mediakeys_create_session_1();
 extern  rpc_response_create_session * rpc_open_cdm_mediakeys_create_session_1_svc();
+extern  rpc_response_generic * rpc_open_cdm_mediakeysession_load_1(rpc_request_session_load *, CLIENT *);
+extern  rpc_response_generic * rpc_open_cdm_mediakeysession_load_1_svc(rpc_request_session_load *, struct svc_req *);
 #define RPC_OPEN_CDM_MEDIAKEYS_LOAD_SESSION 4
+#define RPC_OPEN_CDM_MEDIAKEYSESSION_UPDATE 5
 extern  rpc_response_generic * rpc_open_cdm_mediakeys_load_session_1();
 extern  rpc_response_generic * rpc_open_cdm_mediakeys_load_session_1_svc();
-#define RPC_OPEN_CDM_MEDIAKEYSESSION_UPDATE 5
 extern  rpc_response_generic * rpc_open_cdm_mediakeysession_update_1();
 extern  rpc_response_generic * rpc_open_cdm_mediakeysession_update_1_svc();
 #define RPC_OPEN_CDM_MEDIAKEYSESSION_RELEASE 6
@@ -166,6 +210,15 @@ extern  rpc_response_generic * rpc_open_cdm_mediakeysession_release_1_svc();
 #define RPC_OPEN_CDM_MEDIAENGINE 7
 extern  rpc_response_generic * rpc_open_cdm_mediaengine_1();
 extern  rpc_response_generic * rpc_open_cdm_mediaengine_1_svc();
+#define RPC_OPEN_CDM_MEDIAKEYS_SET_SERVER_CERTIFICATE 8
+extern  rpc_response_generic * rpc_open_cdm_mediakeys_set_server_certificate_1(rpc_request_certificate *, CLIENT *);
+extern  rpc_response_generic * rpc_open_cdm_mediakeys_set_server_certificate_1_svc(rpc_request_certificate *, struct svc_req *);
+#define RPC_OPEN_CDM_MEDIAKEYSESSION_REMOVE 9
+extern  rpc_response_generic * rpc_open_cdm_mediakeysession_remove_1(rpc_request_session_remove *, CLIENT *);
+extern  rpc_response_generic * rpc_open_cdm_mediakeysession_remove_1_svc(rpc_request_session_remove *, struct svc_req *);
+#define RPC_OPEN_CDM_MEDIAKEYSESSION_CLOSE 10
+extern  rpc_response_generic * rpc_open_cdm_mediakeysession_close_1(rpc_request_session_close *, CLIENT *);
+extern  rpc_response_generic * rpc_open_cdm_mediakeysession_close_1_svc(rpc_request_session_close *, struct svc_req *);
 extern int open_cdm_1_freeresult ();
 #endif /* K&R C */
 
@@ -174,10 +227,14 @@ extern int open_cdm_1_freeresult ();
 #if defined(__STDC__) || defined(__cplusplus)
 extern  bool_t xdr_rpc_request_is_type_supported (XDR *, rpc_request_is_type_supported*);
 extern  bool_t xdr_rpc_request_mediakeys (XDR *, rpc_request_mediakeys*);
+extern  bool_t xdr_rpc_request_certificate (XDR *, rpc_request_certificate*);
 extern  bool_t xdr_rpc_request_callback_info (XDR *, rpc_request_callback_info*);
 extern  bool_t xdr_rpc_request_create_session (XDR *, rpc_request_create_session*);
+extern  bool_t xdr_rpc_request_session_load (XDR *, rpc_request_session_load*);
 extern  bool_t xdr_rpc_request_load_session (XDR *, rpc_request_load_session*);
 extern  bool_t xdr_rpc_request_session_update (XDR *, rpc_request_session_update*);
+extern  bool_t xdr_rpc_request_session_remove (XDR *, rpc_request_session_remove*);
+extern  bool_t xdr_rpc_request_session_close (XDR *, rpc_request_session_close*);
 extern  bool_t xdr_rpc_request_session_release (XDR *, rpc_request_session_release*);
 extern  bool_t xdr_rpc_request_mediaengine_data (XDR *, rpc_request_mediaengine_data*);
 extern  bool_t xdr_rpc_response_generic (XDR *, rpc_response_generic*);

--- a/src/com/common/rpc/opencdm_xdr.x
+++ b/src/com/common/rpc/opencdm_xdr.x
@@ -16,6 +16,10 @@ struct rpc_request_mediakeys {
     char key_system <>;
 };
 
+struct rpc_request_certificate {
+    uint8_t certificate <>;
+};
+
 struct rpc_request_callback_info {
     char hostname <>;
     uint64_t prog_num;
@@ -28,6 +32,9 @@ struct rpc_request_create_session {
     rpc_request_callback_info callback_info;
 };
 
+struct rpc_request_session_load {
+    char session_id <>;
+};
 struct rpc_request_load_session {
     char session_id <>;
 };
@@ -35,6 +42,14 @@ struct rpc_request_load_session {
 struct rpc_request_session_update {
     char session_id <>;
     uint8_t key <>;
+};
+
+struct rpc_request_session_remove {
+    char session_id <>;
+};
+
+struct rpc_request_session_close {
+    char session_id <>;
 };
 
 struct rpc_request_session_release {
@@ -71,5 +86,8 @@ program OPEN_CDM {
     rpc_response_generic RPC_OPEN_CDM_MEDIAKEYSESSION_UPDATE(rpc_request_session_update) = 5;
     rpc_response_generic RPC_OPEN_CDM_MEDIAKEYSESSION_RELEASE(rpc_request_session_release) = 6;
     rpc_response_generic RPC_OPEN_CDM_MEDIAENGINE(rpc_request_mediaengine_data) = 7;
+    rpc_response_generic RPC_OPEN_CDM_MEDIAKEYS_SET_SERVER_CERTIFICATE(rpc_request_certificate) = 8;
+    rpc_response_generic RPC_OPEN_CDM_MEDIAKEYSESSION_REMOVE(rpc_request_session_remove) = 9;
+    rpc_response_generic RPC_OPEN_CDM_MEDIAKEYSESSION_CLOSE(rpc_request_session_close) = 10;
     } = 1;
 } = 0x61135687; /* FAMEFHG */

--- a/src/com/common/rpc/opencdm_xdr_clnt.c
+++ b/src/com/common/rpc/opencdm_xdr_clnt.c
@@ -39,6 +39,21 @@ rpc_open_cdm_mediakeys_1(rpc_request_mediakeys *argp, CLIENT *clnt)
 	return (&clnt_res);
 }
 
+rpc_response_generic *
+rpc_open_cdm_mediakeys_set_server_certificate_1(rpc_request_certificate *argp, CLIENT *clnt)
+{
+	static rpc_response_generic clnt_res;
+
+	memset((char *)&clnt_res, 0, sizeof(clnt_res));
+	if (clnt_call (clnt, RPC_OPEN_CDM_MEDIAKEYS_SET_SERVER_CERTIFICATE,
+		(xdrproc_t) xdr_rpc_request_certificate, (caddr_t) argp,
+		(xdrproc_t) xdr_rpc_response_generic, (caddr_t) &clnt_res,
+		TIMEOUT) != RPC_SUCCESS) {
+		return (NULL);
+	}
+	return (&clnt_res);
+}
+
 rpc_response_create_session *
 rpc_open_cdm_mediakeys_create_session_1(rpc_request_create_session *argp, CLIENT *clnt)
 {
@@ -77,6 +92,37 @@ rpc_open_cdm_mediakeysession_update_1(rpc_request_session_update *argp, CLIENT *
 	memset((char *)&clnt_res, 0, sizeof(clnt_res));
 	if (clnt_call (clnt, RPC_OPEN_CDM_MEDIAKEYSESSION_UPDATE,
 		(xdrproc_t) xdr_rpc_request_session_update, (caddr_t) argp,
+		(xdrproc_t) xdr_rpc_response_generic, (caddr_t) &clnt_res,
+		TIMEOUT) != RPC_SUCCESS) {
+		return (NULL);
+	}
+        int i;
+	return (&clnt_res);
+}
+
+rpc_response_generic *
+rpc_open_cdm_mediakeysession_remove_1(rpc_request_session_remove *argp, CLIENT *clnt)
+{
+	static rpc_response_generic clnt_res;
+
+	memset((char *)&clnt_res, 0, sizeof(clnt_res));
+	if (clnt_call (clnt, RPC_OPEN_CDM_MEDIAKEYSESSION_REMOVE,
+		(xdrproc_t) xdr_rpc_request_session_remove, (caddr_t) argp,
+		(xdrproc_t) xdr_rpc_response_generic, (caddr_t) &clnt_res,
+		TIMEOUT) != RPC_SUCCESS) {
+		return (NULL);
+	}
+	return (&clnt_res);
+}
+
+rpc_response_generic *
+rpc_open_cdm_mediakeysession_close_1(rpc_request_session_close *argp, CLIENT *clnt)
+{
+	static rpc_response_generic clnt_res;
+
+	memset((char *)&clnt_res, 0, sizeof(clnt_res));
+	if (clnt_call (clnt, RPC_OPEN_CDM_MEDIAKEYSESSION_CLOSE,
+		(xdrproc_t) xdr_rpc_request_session_close, (caddr_t) argp,
 		(xdrproc_t) xdr_rpc_response_generic, (caddr_t) &clnt_res,
 		TIMEOUT) != RPC_SUCCESS) {
 		return (NULL);

--- a/src/com/common/rpc/opencdm_xdr_xdr.c
+++ b/src/com/common/rpc/opencdm_xdr_xdr.c
@@ -29,9 +29,17 @@ xdr_rpc_request_mediakeys (XDR *xdrs, rpc_request_mediakeys *objp)
 }
 
 bool_t
+xdr_rpc_request_certificate (XDR *xdrs, rpc_request_certificate *objp)
+{
+	 if (!xdr_array (xdrs, (char **)&objp->certificate.certificate_val, (u_int *) &objp->certificate.certificate_len, ~0,
+		sizeof (uint8_t), (xdrproc_t) xdr_uint8_t))
+		 return FALSE;
+	return TRUE;
+}
+
+bool_t
 xdr_rpc_request_callback_info (XDR *xdrs, rpc_request_callback_info *objp)
 {
-
 	 if (!xdr_array (xdrs, (char **)&objp->hostname.hostname_val, (u_int *) &objp->hostname.hostname_len, ~0,
 		sizeof (char), (xdrproc_t) xdr_char))
 		 return FALSE;
@@ -58,9 +66,17 @@ xdr_rpc_request_create_session (XDR *xdrs, rpc_request_create_session *objp)
 }
 
 bool_t
+xdr_rpc_request_session_load (XDR *xdrs, rpc_request_session_load *objp)
+{
+         if (!xdr_array (xdrs, (char **)&objp->session_id.session_id_val, (u_int *) &objp->session_id.session_id_len, ~0,
+                sizeof (char), (xdrproc_t) xdr_char))
+                 return FALSE;
+        return TRUE;
+}
+
+bool_t
 xdr_rpc_request_load_session (XDR *xdrs, rpc_request_load_session *objp)
 {
-
 	 if (!xdr_array (xdrs, (char **)&objp->session_id.session_id_val, (u_int *) &objp->session_id.session_id_len, ~0,
 		sizeof (char), (xdrproc_t) xdr_char))
 		 return FALSE;
@@ -81,9 +97,26 @@ xdr_rpc_request_session_update (XDR *xdrs, rpc_request_session_update *objp)
 }
 
 bool_t
+xdr_rpc_request_session_remove (XDR *xdrs, rpc_request_session_remove *objp)
+{
+	 if (!xdr_array (xdrs, (char **)&objp->session_id.session_id_val, (u_int *) &objp->session_id.session_id_len, ~0,
+		sizeof (char), (xdrproc_t) xdr_char))
+		 return FALSE;
+	return TRUE;
+}
+
+bool_t
+xdr_rpc_request_session_close (XDR *xdrs, rpc_request_session_close *objp)
+{
+	 if (!xdr_array (xdrs, (char **)&objp->session_id.session_id_val, (u_int *) &objp->session_id.session_id_len, ~0,
+		sizeof (char), (xdrproc_t) xdr_char))
+		 return FALSE;
+	return TRUE;
+}
+
+bool_t
 xdr_rpc_request_session_release (XDR *xdrs, rpc_request_session_release *objp)
 {
-
 	 if (!xdr_array (xdrs, (char **)&objp->session_id.session_id_val, (u_int *) &objp->session_id.session_id_len, ~0,
 		sizeof (char), (xdrproc_t) xdr_char))
 		 return FALSE;
@@ -93,7 +126,6 @@ xdr_rpc_request_session_release (XDR *xdrs, rpc_request_session_release *objp)
 bool_t
 xdr_rpc_request_mediaengine_data (XDR *xdrs, rpc_request_mediaengine_data *objp)
 {
-
 	 if (!xdr_array (xdrs, (char **)&objp->session_id.session_id_val, (u_int *) &objp->session_id.session_id_len, ~0,
 		sizeof (char), (xdrproc_t) xdr_char))
 		 return FALSE;

--- a/src/com/common/shmemsem/shmemsem_helper.cc
+++ b/src/com/common/shmemsem/shmemsem_helper.cc
@@ -17,7 +17,7 @@
 /*
  * based on Keith Gaughan - Shared Memory and Semaphores - March 22, 2003
  */
-#include "media/cdm/ppapi/external_open_cdm/src/com/common/shmemsem/shmemsem_helper.h"
+#include "shmemsem_helper.h"
 
 /**
  * Allocates a shared memory segment.

--- a/src/com/mediaengine/rpc/rpc_cdm_mediaengine_handler.h
+++ b/src/com/mediaengine/rpc/rpc_cdm_mediaengine_handler.h
@@ -20,8 +20,8 @@
 #include <rpc/rpc.h>
 #include <string>
 
-#include "media/cdm/ppapi/external_open_cdm/src/com/common/shmemsem/shmemsem_helper.h"
-#include "media/cdm/ppapi/external_open_cdm/src/mediaengine/open_cdm_mediaengine_com.h"
+#include <shmemsem_helper.h>
+#include <open_cdm_mediaengine_com.h>
 
 namespace media {
 
@@ -37,13 +37,16 @@ class RpcCdmMediaengineHandler : public OpenCdmMediaengineCom {
 
   bool CreateMediaEngineSession(char *session_id_val, uint32_t session_id_len,
                            uint8_t *auth_data_val, uint32_t auth_data_len);
+
   DecryptResponse Decrypt(const uint8_t *pbIv, uint32_t cbIv,
                                   const uint8_t *pbData, uint32_t cbData,
                                   uint8_t *out, uint32_t &out_size) override;
+  int ReleaseMem() override;
   //TODO (sph): make out const
   ~RpcCdmMediaengineHandler() override;
 
  private:
+  MediaEngineSessionId sessionId;
   RpcCdmMediaengineHandler();
   RpcCdmMediaengineHandler(RpcCdmMediaengineHandler const&);
   void operator=(RpcCdmMediaengineHandler const&);

--- a/src/common/cdm_logging.h
+++ b/src/common/cdm_logging.h
@@ -1,0 +1,11 @@
+
+#ifndef MEDIA_CDM__CDM_LOGGING_H_
+#define MEDIA_CDM__CDM_LOGGING_H_
+
+#include <iostream>
+namespace media {
+
+#define CDM_DLOG() std::cout << "\n" <<__FILE__<<":"<<  __func__ <<":"<< __LINE__ <<"::"
+}  // namespace media
+
+#endif  // MEDIA_CDM_CDM_LOGGING_H_

--- a/src/common/open_cdm_common.h
+++ b/src/common/open_cdm_common.h
@@ -18,9 +18,11 @@
 #define MEDIA_CDM_PPAPI_EXTERNAL_OPEN_CDM_COMMON_OPEN_CDM_COMMON_H_
 
 #ifdef OCDM_USE_PLAYREADY
-#include "media/cdm/ppapi/external_open_cdm/src/include/playready/constants.h"
+#include "playready/constants.h"
 #else
-#include "media/cdm/ppapi/external_open_cdm/src/include/clearkey/constants.h"
+#ifdef CLEAR_KEY_CDM_USE_FFMPEG_DECODER
+#include "clearkey/constants.h"
+#endif
 #endif
 
 

--- a/src/mediaengine/open_cdm_mediaengine.h
+++ b/src/mediaengine/open_cdm_mediaengine.h
@@ -17,7 +17,7 @@
 #ifndef MEDIA_CDM_PPAPI_EXTERNAL_OPEN_CDM_MEDIAENGINE_OPEN_CDM_MEDIAENGINE_H_
 #define MEDIA_CDM_PPAPI_EXTERNAL_OPEN_CDM_MEDIAENGINE_OPEN_CDM_MEDIAENGINE_H_
 
-#include "media/cdm/ppapi/external_open_cdm/src/cdm/open_cdm_platform_common.h"
+#include <open_cdm_platform_common.h>
 
 namespace media {
 
@@ -65,6 +65,7 @@ class OpenCdmMediaengine {
                                   const uint8_t *pbData, uint32_t cbData,
                                   uint8_t *out, uint32_t &out_size) = 0;
 
+  virtual int ReleaseMem() = 0;
  protected:
   OpenCdmMediaengine(char *session_id_val, uint32_t session_id_len);
   OpenCdmMediaengine() {

--- a/src/mediaengine/open_cdm_mediaengine_com.h
+++ b/src/mediaengine/open_cdm_mediaengine_com.h
@@ -17,7 +17,7 @@
 #ifndef MEDIA_CDM_PPAPI_EXTERNAL_OPEN_CDM_MEDIAENGINE_OPEN_CDM_MEDIAENGINE_COM_H_
 #define MEDIA_CDM_PPAPI_EXTERNAL_OPEN_CDM_MEDIAENGINE_OPEN_CDM_MEDIAENGINE_COM_H_
 
-#include "media/cdm/ppapi/external_open_cdm/src/mediaengine/open_cdm_mediaengine.h"
+#include "open_cdm_mediaengine.h"
 
 namespace media {
 

--- a/src/mediaengine/open_cdm_mediaengine_factory.h
+++ b/src/mediaengine/open_cdm_mediaengine_factory.h
@@ -19,18 +19,22 @@
 
 #include <string>
 
-#include "media/cdm/ppapi/external_open_cdm/src/mediaengine/open_cdm_mediaengine.h"
-#include "media/cdm/ppapi/external_open_cdm/src/mediaengine/open_cdm_mediaengine_impl.h"
-
-#include "media/cdm/ppapi/cdm_logging.h"
+#include "open_cdm_mediaengine.h"
+#include "open_cdm_mediaengine_impl.h"
+#include "cdm_logging.h"
 
 namespace media {
 
 #ifdef OCDM_USE_PLAYREADY
 const std::string open_cdm_key_system = "com.microsoft.playready";
 #else
+#ifdef CLEAR_KEY_CDM_USE_FFMPEG_DECODER
 const std::string open_cdm_key_system = "org.chromium.externalclearkey";
+#else
+const std::string open_cdm_key_system = "org.w3.clearkey";
 #endif
+#endif
+
 
 // TODO(ska): outsource the mapping of key system string
 // to mediaengine and platform implementations
@@ -47,7 +51,7 @@ class OpenCdmMediaengineFactory {
  */
 OpenCdmMediaengine *OpenCdmMediaengineFactory::Create(
     std::string key_system, OpenCdmPlatformSessionId session_id) {
-  if (key_system == open_cdm_key_system) {
+  if (!key_system.compare(open_cdm_key_system)) {
     CDM_DLOG() << "Instantiate OpenCdmMediaengineImpl!";
     return new OpenCdmMediaengineImpl(session_id.session_id,
                                       session_id.session_id_len);

--- a/src/mediaengine/open_cdm_mediaengine_impl.cc
+++ b/src/mediaengine/open_cdm_mediaengine_impl.cc
@@ -14,23 +14,21 @@
  * limitations under the License.
  */
 
-#include "media/cdm/ppapi/external_open_cdm/src/mediaengine/open_cdm_mediaengine_impl.h"
-#include "media/cdm/ppapi/external_open_cdm/src/com/mediaengine/rpc/rpc_cdm_mediaengine_handler.h"
-
-#include "media/cdm/ppapi/cdm_logging.h"
+#include "open_cdm_mediaengine_impl.h"
+#include <rpc_cdm_mediaengine_handler.h>
+#include <cdm_logging.h>
 
 namespace media {
 
 OpenCdmMediaengineImpl::OpenCdmMediaengineImpl(char *session_id_val,
                                                uint32_t session_id_len) {
   media_engine_com_ = &(RpcCdmMediaengineHandler::getInstance());
+  CDM_DLOG() << "Created new media engine impl ";
 
   if( !media_engine_com_->CreateMediaEngineSession(session_id_val,
       session_id_len, 0, 0)) {
     CDM_DLOG() << "Failed to create media engine session";
   }
-
-  CDM_DLOG() << "Created new media engine impl ";
 }
 
 OpenCdmMediaengineImpl::OpenCdmMediaengineImpl(char *session_id_val,
@@ -66,4 +64,10 @@ DecryptResponse OpenCdmMediaengineImpl::Decrypt(const uint8_t *pbIv,
   return response;
 }
 
+int OpenCdmMediaengineImpl::ReleaseMem() {
+  CDM_DLOG() << "OpenCdmMediaengineImpl::ReleaseMem ";
+  int response;
+  response = media_engine_com_->ReleaseMem();
+  return response;
+}
 }  // namespace media

--- a/src/mediaengine/open_cdm_mediaengine_impl.h
+++ b/src/mediaengine/open_cdm_mediaengine_impl.h
@@ -17,11 +17,12 @@
 #ifndef MEDIA_CDM_PPAPI_EXTERNAL_OPEN_CDM_MEDIAENGINE_OPEN_CDM_MEDIAENGINE_IMPL_H_
 #define MEDIA_CDM_PPAPI_EXTERNAL_OPEN_CDM_MEDIAENGINE_OPEN_CDM_MEDIAENGINE_IMPL_H_
 
-#include "media/cdm/ppapi/external_open_cdm/src/mediaengine/open_cdm_mediaengine.h"
+#include "open_cdm_mediaengine.h"
+#include "open_cdm_mediaengine_com.h"
 #include <rpc/rpc.h>
 #include <string>
-#include "media/cdm/ppapi/external_open_cdm/src/com/common/shmemsem/shmemsem_helper.h"
-#include "media/cdm/ppapi/external_open_cdm/src/com/mediaengine/rpc/rpc_cdm_mediaengine_handler.h"
+#include "shmemsem_helper.h"
+#include "rpc_cdm_mediaengine_handler.h"
 
 namespace media {
 
@@ -42,6 +43,7 @@ class OpenCdmMediaengineImpl : public OpenCdmMediaengine {
                                   const uint8_t *pbData, uint32_t cbData,
                                   uint8_t *out, uint32_t &out_size) override;
 
+  int ReleaseMem() override;
   ~OpenCdmMediaengineImpl() override;
  private:
   RpcCdmMediaengineHandler *media_engine_com_;


### PR DESCRIPTION
unifying between WPE browser and Chromium changes

Below EMI APIs are newly added
* MediaKeySetServerCertificate
* MediaKeySessionRemove
* MediaKeySessionClose

These changes has been validated in WPE browser and Chromium 53 using ClearKey with OP-TEE

Base Reference: https://github.com/WebPlatformForEmbedded/WPEOpenCDM/tree/4ad5cb97e16ac4a46f7c284e6e7e6fea843397d3

Signed-off-by: psivasubramanian <sivasubramanian.patchaiperumal@linaro.org>
Signed-off-by: Moorthy B S <moorthy.baskaravenkatraman-sambamoorthy@linaro.org>