### PR TITLE
Add Chromium v65 Playready support

### DIFF
--- a/src/browser/BUILD.gn
+++ b/src/browser/BUILD.gn
@@ -76,6 +76,10 @@ if (enable_opencdm && enable_library_cdms) {
       "../mediaengine/open_cdm_mediaengine_impl.h",
     ]
 
+    include_dirs = [
+      "$target_gen_dir/",
+    ]
+
     # TODO(jschuh): crbug.com/167187 fix size_t to int truncations.
     configs += [ "//build/config/compiler:no_size_t_to_int_warning" ]
 
@@ -142,6 +146,10 @@ source_set("opencdm_ks") {
   sources = [
     "opencdm_key_systems.cc",
     "opencdm_key_systems.h",
+  ]
+
+  include_dirs = [
+      "$target_gen_dir/",
   ]
 
   deps = [

--- a/src/browser/BUILD.gn
+++ b/src/browser/BUILD.gn
@@ -126,6 +126,7 @@ if (enable_opencdm && enable_library_cdms) {
 
     deps = [
       ":opencdm",
+      ":opencdm_features",
       "//base",
       "//media:shared_memory_support",
       "//ui/gfx/geometry",
@@ -149,5 +150,6 @@ source_set("opencdm_ks") {
     "//content/public/renderer",
     "//media",
     "//media:media_features",   # for ENABLE_LIBRARY_CDMS
+    ":opencdm_features",
   ]
 }

--- a/src/browser/BUILD.gn
+++ b/src/browser/BUILD.gn
@@ -23,15 +23,26 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//build/buildflag_header.gni")
 import("//build/config/features.gni")
 import("//media/cdm/ppapi/cdm_paths.gni")
 import("//media/cdm/ppapi/external_open_cdm/opencdm.gni")
 import("//media/cdm/ppapi/ppapi_cdm_adapter.gni")
 import("//media/media_options.gni")
 
+buildflag_header("opencdm_features") {
+  header = "opencdm_features.h"
+
+  flags = [
+    "OCDM_USE_PLAYREADY=$playready",
+  ]
+}
+
 if (enable_opencdm && enable_library_cdms) {
   shared_library("opencdm") {
     sources = [
+      "//media/cdm/ppapi/cdm_logging.cc",
+      "//media/cdm/ppapi/cdm_logging.h",
       "../../../clear_key_cdm/cdm_host_proxy.h",
       "../../../clear_key_cdm/cdm_host_proxy_impl.h",
       "../../../clear_key_cdm/cdm_video_decoder.cc",
@@ -97,10 +108,6 @@ if (enable_opencdm && enable_library_cdms) {
       ldflags += [
         "-Wl,-Bsymbolic",
       ]
-    }
-
-    if (playready) {
-      defines += [ "OCDM_USE_PLAYREADY" ]
     }
 
     if (is_mac) {

--- a/src/browser/chrome/tests/ocdm_encrypted_media_istypesupported_browsertest.cc
+++ b/src/browser/chrome/tests/ocdm_encrypted_media_istypesupported_browsertest.cc
@@ -43,7 +43,7 @@
 #error This file needs to be updated to run on Android.
 #endif
 
-#if defined(USE_PROPRIETARY_CODECS)
+#if BUILDFLAG(USE_PROPRIETARY_CODECS)
 #define EXPECT_PROPRIETARY EXPECT_TRUE
 #else
 #define EXPECT_PROPRIETARY EXPECT_FALSE
@@ -55,7 +55,7 @@
 
 namespace chrome {
 
-#if defined(ENABLE_PEPPER_CDMS)
+#if BUILDFLAG(ENABLE_PEPPER_CDMS)
 
 const char kOpenCDM[] = "com.opencdm.mockdrm";
 const char kOpenCDMParentOnly[] = "com.opencdm";

--- a/src/browser/opencdm_key_systems.cc
+++ b/src/browser/opencdm_key_systems.cc
@@ -20,7 +20,7 @@
 #include "media/base/key_system_properties.h"
 #include "media/media_features.h"
 #include "opencdm_key_systems.h"
-#include "media/cdm/ppapi/external_open_cdm/src/browser/opencdm_features.h"
+#include "opencdm_features.h"
 using namespace media;
 
 #if BUILDFLAG(ENABLE_LIBRARY_CDMS)

--- a/src/browser/opencdm_key_systems.cc
+++ b/src/browser/opencdm_key_systems.cc
@@ -45,7 +45,7 @@ class PlayreadyKeyProperties : public KeySystemProperties {
         return true;
 
       case media::EmeInitDataType::CENC:
-#if defined(USE_PROPRIETARY_CODECS)
+#if BUILDFLAG(USE_PROPRIETARY_CODECS)
         return true;
 #else
         return false;
@@ -59,7 +59,7 @@ class PlayreadyKeyProperties : public KeySystemProperties {
   }
 
   SupportedCodecs GetSupportedCodecs() const override {
-#if defined(USE_PROPRIETARY_CODECS)
+#if BUILDFLAG(USE_PROPRIETARY_CODECS)
     return media::EME_CODEC_MP4_ALL | media::EME_CODEC_WEBM_ALL;
 #else
     return media::EME_CODEC_WEBM_ALL;
@@ -121,7 +121,7 @@ class ExternalOpenCdmKeyProperties : public KeySystemProperties {
         return true;
 
       case media::EmeInitDataType::CENC:
-#if defined(USE_PROPRIETARY_CODECS)
+#if BUILDFLAG(USE_PROPRIETARY_CODECS)
         return true;
 #else
         return false;
@@ -135,7 +135,7 @@ class ExternalOpenCdmKeyProperties : public KeySystemProperties {
   }
 
   SupportedCodecs GetSupportedCodecs() const override {
-#if defined(USE_PROPRIETARY_CODECS)
+#if BUILDFLAG(USE_PROPRIETARY_CODECS)
     return media::EME_CODEC_MP4_ALL | media::EME_CODEC_WEBM_ALL;
 #else
     return media::EME_CODEC_WEBM_ALL;

--- a/src/browser/opencdm_key_systems.cc
+++ b/src/browser/opencdm_key_systems.cc
@@ -25,7 +25,7 @@ using namespace media;
 
 #if BUILDFLAG(ENABLE_LIBRARY_CDMS)
 
-#ifdef OCDM_USE_PLAYREADY
+#if BUILDFLAG(OCDM_USE_PLAYREADY)
 static const char kPlayreadyKeySystem[] =
     "com.microsoft.playready";
 static const char kPlayreadyPepperType[] =
@@ -179,7 +179,7 @@ class ExternalOpenCdmKeyProperties : public KeySystemProperties {
 #endif
 
 void AddExternalOpenCdmKeySystems(std::vector<std::unique_ptr<KeySystemProperties>>* key_systems) {
-#ifdef OCDM_USE_PLAYREADY
+#if BUILDFLAG(OCDM_USE_PLAYREADY)
   //TODO: AddPlayreadyKeySystem(key_systems);
   key_systems->emplace_back(
     new PlayreadyKeyProperties(kPlayreadyKeySystem));

--- a/src/browser/opencdm_key_systems.cc
+++ b/src/browser/opencdm_key_systems.cc
@@ -20,6 +20,7 @@
 #include "media/base/key_system_properties.h"
 #include "media/media_features.h"
 #include "opencdm_key_systems.h"
+#include "media/cdm/ppapi/external_open_cdm/src/browser/opencdm_features.h"
 using namespace media;
 
 #if BUILDFLAG(ENABLE_LIBRARY_CDMS)

--- a/src/common/open_cdm_common.h
+++ b/src/common/open_cdm_common.h
@@ -17,7 +17,7 @@
 #ifndef MEDIA_CDM_PPAPI_EXTERNAL_OPEN_CDM_COMMON_OPEN_CDM_COMMON_H_
 #define MEDIA_CDM_PPAPI_EXTERNAL_OPEN_CDM_COMMON_OPEN_CDM_COMMON_H_
 
-#include "media/cdm/ppapi/external_open_cdm/src/browser/opencdm_features.h"
+#include "opencdm_features.h"
 
 #if BUILDFLAG(OCDM_USE_PLAYREADY)
 #include "media/cdm/ppapi/external_open_cdm/src/include/playready/constants.h"

--- a/src/common/open_cdm_common.h
+++ b/src/common/open_cdm_common.h
@@ -17,7 +17,9 @@
 #ifndef MEDIA_CDM_PPAPI_EXTERNAL_OPEN_CDM_COMMON_OPEN_CDM_COMMON_H_
 #define MEDIA_CDM_PPAPI_EXTERNAL_OPEN_CDM_COMMON_OPEN_CDM_COMMON_H_
 
-#ifdef OCDM_USE_PLAYREADY
+#include "media/cdm/ppapi/external_open_cdm/src/browser/opencdm_features.h"
+
+#if BUILDFLAG(OCDM_USE_PLAYREADY)
 #include "media/cdm/ppapi/external_open_cdm/src/include/playready/constants.h"
 #else
 #include "media/cdm/ppapi/external_open_cdm/src/include/clearkey/constants.h"

--- a/src/mediaengine/open_cdm_mediaengine_factory.h
+++ b/src/mediaengine/open_cdm_mediaengine_factory.h
@@ -21,7 +21,7 @@
 
 #include "media/cdm/ppapi/external_open_cdm/src/mediaengine/open_cdm_mediaengine.h"
 #include "media/cdm/ppapi/external_open_cdm/src/mediaengine/open_cdm_mediaengine_impl.h"
-#include "media/cdm/ppapi/external_open_cdm/src/browser/opencdm_features.h"
+#include "opencdm_features.h"
 #include "media/cdm/ppapi/cdm_logging.h"
 
 namespace media {

--- a/src/mediaengine/open_cdm_mediaengine_factory.h
+++ b/src/mediaengine/open_cdm_mediaengine_factory.h
@@ -21,12 +21,12 @@
 
 #include "media/cdm/ppapi/external_open_cdm/src/mediaengine/open_cdm_mediaengine.h"
 #include "media/cdm/ppapi/external_open_cdm/src/mediaengine/open_cdm_mediaengine_impl.h"
-
+#include "media/cdm/ppapi/external_open_cdm/src/browser/opencdm_features.h"
 #include "media/cdm/ppapi/cdm_logging.h"
 
 namespace media {
 
-#ifdef OCDM_USE_PLAYREADY
+#ifdef BUILDFLAG(OCDM_USE_PLAYREADY)
 const std::string open_cdm_key_system = "com.microsoft.playready";
 #else
 const std::string open_cdm_key_system = "org.chromium.externalclearkey";


### PR DESCRIPTION
With these patches applied Playready content is being played with the following command

chromium --no-sandbox --start-maximized --user-data-dir=data_dir --enable-logging --v=0 --unsafely-treat-insecure-origin-as-secure="http://people.linaro.org" --register-pepper-plugins="/usr/lib64/chromium/libopencdmadapter.so#ClearKey CDM#ClearKey CDM0.1.0.0#1.0.0;application/x-ppapi-open-cdm" http://people.linaro.org/~peter.griffin/dash.js/samples/dash-if-reference-player/index.html